### PR TITLE
Copied content from `README.md` to `index.md`

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,44 +2,87 @@
 layout: front
 ---
 
-<a href="https://youtu.be/GVcCW8WgEDY"><img alt="ILLIXR Simple Demo" src="https://img.youtube.com/vi/GVcCW8WgEDY/0.jpg" style="width: 320px" class="center"></a>
+<a href="https://youtu.be/GVcCW8WgEDY">
+    <img
+        alt="ILLIXR Simple Demo"
+        src="https://img.youtube.com/vi/GVcCW8WgEDY/0.jpg"
+        style="width: 320px"
+        class="center"
+    >
+</a>
 
-Illinois Extended Reality testbed or ILLIXR (pronounced like elixir) is the first fully open-source Extended Reality (XR) system and testbed. The modular, extensible, and [OpenXR](https://www.khronos.org/openxr)-compatible ILLIXR runtime integrates state-of-the-art XR components into a complete XR system. The testbed is part of the broader [ILLIXR consortium](http://illixr.org), an industry-supported community effort to democratize XR systems research, development, and benchmarking.
+Illinois Extended Reality testbed or ILLIXR (pronounced like elixir) is
+    the first fully open-source Extended Reality (XR) system and testbed.
+The modular, extensible, and [OpenXR][26]-compatible ILLIXR runtime
+    integrates state-of-the-art XR components into a complete XR system.
+The testbed is part of the broader [ILLIXR consortium][37],
+    an industry-supported community effort to democratize XR systems
+    research, development, and benchmarking.
 
-You can find the complete ILLIXR system [here](https://github.com/ILLIXR/ILLIXR).
+You can find the complete ILLIXR system [here][38].
 
-ILLIXR also provides its components in standalone configurations to enable architects and system designers to research each component in isolation. The standalone components are packaged together in the [v1-latest release](https://github.com/ILLIXR/ILLIXR/releases/tag/v1-latest) of ILLIXR. 
+ILLIXR also provides its components in standalone configurations to enable architects and
+    system designers to research each component in isolation.
+The standalone components are packaged together in the [v1-latest release][39] of ILLIXR. 
 
-ILLIXR's modular and extensible runtime allows adding new components and swapping different implementations of a given component. ILLIXR currently contains the following components: 
+ILLIXR's modular and extensible runtime allows adding new components and swapping different
+    implementations of a given component.
+ILLIXR currently contains the following components: 
 
-1. Cameras and IMUs: [ZED Mini](https://github.com/ILLIXR/ILLIXR/tree/master/zed), [Intel RealSense](https://github.com/ILLIXR/ILLIXR/tree/master/realsense)
-2. Visual Inertial Odometry: [OpenVINS](https://github.com/ILLIXR/open_vins), [Kimera-VIO](https://github.com/ILLIXR/Kimera-VIO)
-3. Scene reconstruction: [ElasticFusion](https://github.com/ILLIXR/ElasticFusion), [KinectFusion](https://github.com/ILLIXR/KinectFusionApp/tree/illixr-integration)
-4. [Eye tracking](https://github.com/ILLIXR/RITnet)
-5. [Ambisonic encoding](https://github.com/ILLIXR/audio_pipeline)
-6. [Ambisonic manipulation and binauralization](https://github.com/ILLIXR/audio_pipeline)
-7. [Lens distortion correction](https://github.com/ILLIXR/visual_postprocessing)
-8. [Chromatic aberration correction](https://github.com/ILLIXR/visual_postprocessing)
-9. [Asynchronous reprojection (Time warp)](https://github.com/ILLIXR/visual_postprocessing)
-10. [Computational holography for adaptive multi-focal displays](https://github.com/ILLIXR/HOTlab)
+-   *Perception*
+    -   Eye Tracking
+        1.  [RITNet][3] **
+    -   Scene Reconstruction
+        1.  [ElasticFusion][2] **
+        1.  [KinectFusion][40] **
+    -   Simultaneous Localization and Mapping
+        1.  [OpenVINS][1] **
+        1.  [Kimera-VIO][29] **
+    -   Cameras and IMUs
+        1.  [ZED Mini][42]
+        1.  [Intel RealSense][41]
+
+-   *Visual*
+    -   [Chromatic aberration correction][5]
+    -   [Computational holography for adaptive multi-focal displays][6] **
+    -   [Lens distortion correction][5]
+    -   [Asynchronous Reprojection (TimeWarp)][5]
+
+-   *Aural*
+    -   [Audio encoding][4] **
+    -   [Audio playback][4] **
+
+(** Source is hosted in an external repository under the [ILLIXR project][7].)
 
 We continue to add more components (new components and new implementations). 
 
-Many of the current components of ILLIXR were developed by domain experts and obtained from publicly available repositories. They were modified for one or more of the following reasons: fixing compilation, adding features, or removing extraneous code or dependencies. Each component not developed by us is available as a forked github repository for proper attribution to its authors.
+Many of the current components of ILLIXR were developed by domain experts and obtained from
+    publicly available repositories.
+They were modified for one or more of the following reasons: fixing compilation, adding features,
+    or removing extraneous code or dependencies.
+Each component not developed by us is available as a forked github repository for
+    proper attribution to its authors.
 
 # Papers, talks, demos, consortium
 
-A [paper](https://arxiv.org/abs/2004.04643) with details on ILLIXR, including its components, runtime, telemetry support, and a comprehensive analysis of performance, power, and quality on desktop and embedded systems.
+A [paper][8] with details on ILLIXR, including its components, runtime, telemetry support,
+    and a comprehensive analysis of performance, power, and quality on desktop and embedded systems.
 
-A [talk presented at NVIDIA GTC'21](https://www.nvidia.com/en-us/gtc/catalog/?search.primarytopic=option_1564595704881&search.sessiontype=option_1614028602338&search.primaryindustrysegment=option_1563402697134&search=An%20Open-Source%20Testbed#/) describing ILLIXR and announcing the ILLIXR consortium: [Video](https://youtu.be/ZY98lWksnpM). [Slides](https://ws.engr.illinois.edu/sitemanager/getfile.asp?id=2971). 
+A [talk presented at NVIDIA GTC'21][42] describing ILLIXR and announcing the ILLIXR consortium:
+    [Video][43].
+    [Slides][44]. 
 
-A [demo](https://youtu.be/GVcCW8WgEDY) of an OpenXR application running with ILLIXR.
+A [demo][45] of an OpenXR application running with ILLIXR.
 
-The [ILLIXR consortium](http://illixr.org) is an industry-supported community effort to democratize XR systems research, development, and benchmarking. Visit our [web site](http://illixr.org) for more information.
+The [ILLIXR consortium][37] is an industry-supported community effort to democratize
+    XR systems research, development, and benchmarking.
+Visit our [web site][37] for more information.
 
 # Citation
 
-We request that you cite our following [paper](https://arxiv.org/abs/2004.04643) (new version coming soon) when you use ILLIXR for a publication. We would also appreciate it if you send us a citation once your work has been published.
+We request that you cite our following [paper][8] (new version coming soon)
+    when you use ILLIXR for a publication.
+We would also appreciate it if you send us a citation once your work has been published.
 
 ```
 @misc{HuzaifaDesai2020,
@@ -51,37 +94,170 @@ We request that you cite our following [paper](https://arxiv.org/abs/2004.04643)
 }
 ```
 
-# Getting Started and Documentation
+## Getting Started and Documentation
 
-For more information, see our [getting started page](https://illixr.github.io/ILLIXR/getting_started/).
+For more information, see our [Getting Started page][33].
 
-# Acknowledgements
 
-The ILLIXR project started in [Sarita Adve’s research group](http://rsim.cs.illinois.edu/), co-led by PhD candidate Muhammad Huzaifa, at the University of Illinois at Urbana-Champaign. Other major contributors include Rishi Desai, Samuel Grayson, Xutao Jiang, Ying Jing, Jae Lee, Fang Lu, Yihan Pang, Joseph Ravichandran, Giordano Salvador, Finn Sinclair, Boyuan Tian, Henghzhi Yuan, and Jeffrey Zhang.
+## Acknowledgements
 
-ILLIXR came together after many consultations with researchers and practitioners in many domains: audio, graphics, optics, robotics, signal processing, and extended reality systems. We are deeply grateful for all of these discussions and specifically to the following: Wei Cui, Aleksandra Faust, Liang Gao, Matt Horsnell, Amit Jindal, Steve LaValle, Steve Lovegrove, Andrew Maimone, Vegard &#216;ye, Martin Persson, Archontis Politis, Eric Shaffer, Paris Smaragdis, Sachin Talathi, and Chris Widdowson.
+The ILLIXR project started in [Sarita Adve’s research group][9],
+    co-led by PhD candidate Muhammad Huzaifa, at the University of Illinois at Urbana-Champaign.
+Other major contributors include
+    Rishi Desai,
+    Samuel Grayson,
+    Xutao Jiang,
+    Ying Jing,
+    Jae Lee,
+    Fang Lu,
+    Yihan Pang,
+    Joseph Ravichandran,
+    Giordano Salvador,
+    Finn Sinclair,
+    Boyuan Tian,
+    Henghzhi Yuan,
+    and
+    Jeffrey Zhang.
 
-Our OpenXR implementation uses [Monado](https://monado.dev). We are particularly thankful to Jakob Bornecrantz and Ryan Pavlik.
+ILLIXR came together after many consultations with researchers and practitioners in many domains:
+    audio,
+    graphics,
+    optics,
+    robotics,
+    signal processing,
+    and
+    extended reality systems.
+We are deeply grateful for all of these discussions and specifically to the following:
+    Wei Cu,
+    Aleksandra Faust,
+    Liang Gao,
+    Matt Horsnell,
+    Amit Jindal,
+    Steve LaValle,
+    Steve Lovegrove,
+    Andrew Maimone,
+    Vegard &#216;ye,
+    Martin Persson,
+    Archontis Politis,
+    Eric Shaffer,
+    Paris Smaragdis,
+    Sachin Talathi,
+    and
+    Chris Widdowson.
 
-The development of ILLIXR was supported by the Applications Driving Architectures (ADA) Research Center, a JUMP Center co-sponsored by SRC and DARPA, the Center for Future Architectures Research (C-FAR), one of the six centers of STARnet, a Semiconductor Research Corporation program sponsored by MARCO and DARPA, the National Science Foundation under grant CCF 16-19245, DARPA, and by a Google Faculty Research Award. The development of ILLIXR was also aided by generous hardware and software donations from ARM and NVIDIA. Facebook Reality Labs provided the [OpenEDS Semantic Segmentation Dataset](https://research.fb.com/programs/openeds-challenge/).
+Our OpenXR implementation is derived from [Monado][10].
+We are particularly thankful to Jakob Bornecrantz and Ryan Pavlik.
 
-Wesley Darvin came up with the name for ILLIXR. Abdulrahman Mahmoud helped with the design of this website.
+The development of ILLIXR was supported by
+    the Applications Driving Architectures (ADA) Research Center
+        (a JUMP Center co-sponsored by SRC and DARPA),
+    the Center for Future Architectures Research (C-FAR, a STARnet research center),
+    a Semiconductor Research Corporation program sponsored by MARCO and DARPA,
+    and
+    by a Google Faculty Research Award.
+The development of ILLIXR was also aided by generous hardware and software donations
+    from ARM and NVIDIA.
+Facebook Reality Labs provided the [OpenEDS Semantic Segmentation Dataset][11].
 
-# Licensing Structure
+Wesley Darvin came up with the name for ILLIXR.
+Abdulrahman Mahmoud helped with the design of this website.
 
-ILLIXR is available as open-source software under the [University of Illinois/NCSA Open Source License](https://github.com/ILLIXR/illixr.github.io/blob/master/LICENSE). As mentioned above, ILLIXR largely consists of components developed by domain experts and modified for the purposes of inclusion in ILLIXR. However, ILLIXR does contain software developed solely by us. **The NCSA license is limited to only this software**. The external libraries and softwares included in ILLIXR each have their own licenses and must be used according to those licenses:
+## Licensing Structure
 
-- [ElasticFusion](https://github.com/mp3guy/ElasticFusion) \ [ElasticFusion license](https://github.com/mp3guy/ElasticFusion/blob/master/LICENSE.txt)
-- [KinectFusion](https://github.com/ILLIXR/KinectFusionApp/tree/illixr-integration) \ [MIT License](https://github.com/chrdiller/KinectFusionApp/blob/master/LICENSE.txt)
-- [GTSAM](https://github.com/ILLIXR/gtsam) \ [Simplified BSD License](https://github.com/borglab/gtsam/blob/develop/LICENSE.BSD)
-- [HOTlab](https://github.com/MartinPersson/HOTlab) \ [GNU Lesser General Public License v3.0](https://www.gnu.org/licenses/lgpl-3.0.html)
-- [Kimera-VIO](https://github.com/ILLIXR/Kimera-VIO) \ [Simplified BSD License](https://github.com/MIT-SPARK/Kimera-VIO/blob/master/LICENSE.BSD)
-- [libspatialaudio](https://github.com/videolabs/libspatialaudio) \ [GNU Lesser General Public License v2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
-- [Monado](https://gitlab.freedesktop.org/monado/monado) \ [Boost Software License 1.0](https://choosealicense.com/licenses/bsl-1.0)
-- [moodycamel::ConcurrentQueue](https://github.com/cameron314/concurrentqueue) \ [Simplified BSD License](https://github.com/cameron314/concurrentqueue/blob/master/LICENSE.md)
-- [Open-VINS](https://github.com/rpng/open_vins) \ [GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.html)
-- [RITnet](https://github.com/ILLIXR/RITnet) \ [MIT License](https://github.com/AayushKrChaudhary/RITnet/blob/master/License.md)
+ILLIXR is available as open-source software under the permissive
+    [University of Illinois/NCSA Open Source License][34].
+As mentioned above, ILLIXR largely consists of components developed by domain experts and
+    modified for the purposes of inclusion in ILLIXR.
+However, ILLIXR does contain software developed solely by us.
+**The NCSA license is limited to only this software**.
+The external libraries and softwares included in ILLIXR each have their own licenses and
+    must be used according to those licenses:
 
-# Get In Touch
+-   [ElasticFusion][14] \ [ElasticFusion license][15]
 
-Whether you are a computer architect, a compiler writer, a systems person, work on XR related algorithms or applications, or just anyone interested in XR research, development, or products, we would love to hear from you and hope you will contribute! You can join the [ILLIXR consortium](http://illixr.org), [discord](https://discord.gg/upkvy7x3W4), or [mailing list](mailto:lists@lists.cs.illinois.edu?subject=sub%20illixr-community), or send us an [email](mailto:illixr@cs.illinois.edu), or just send us a pull request!
+-   [KinectFusion][40] \ [MIT License][46]
+
+-   [GTSAM][27] \ [Simplified BSD License][28]
+
+-   [HOTlab][20] \ [GNU Lesser General Public License v3.0][21]
+
+-   [Kimera-VIO][29] \ [Simplified BSD License][30]
+
+-   [libspatialaudio][18] \ [GNU Lesser General Public License v2.1][19]
+
+-   [Monado][22] \ [Boost Software License 1.0][23]
+
+-   [moodycamel::ConcurrentQueue][31] \ [Simplified BSD License][32]
+
+-   [Open-VINS][12] \ [GNU General Public License v3.0][13]
+
+-   [RITnet][16] \ [MIT License][17]
+
+Note that ILLIXR's extensibility allows the source to be configured and compiled using only
+    permissively licensed software.
+
+
+## Get in Touch
+
+Whether you are a computer architect, a compiler writer, a systems person, work on XR related algorithms
+    or applications, or just anyone interested in XR research, development, or products,
+    we would love to hear from you and hope you will contribute!
+You can join
+    the [ILLIXR consortium][37],
+    [Discord][47],
+    or [mailing list][48],
+    or send us an [email][49],
+    or just send us a pull request!
+
+
+[//]: # (- References -)
+
+[1]:    https://github.com/ILLIXR/open_vins
+[2]:    https://github.com/ILLIXR/ElasticFusion
+[3]:    https://github.com/ILLIXR/RITnet
+[4]:    https://github.com/ILLIXR/audio_pipeline
+[5]:    https://github.com/ILLIXR/visual_postprocessing
+[6]:    https://github.com/ILLIXR/HOTlab
+[7]:    https://github.com/ILLIXR
+[8]:    https://arxiv.org/pdf/2004.04643.pdf
+[9]:    http://rsim.cs.illinois.edu
+[10]:   https://monado.dev
+[11]:   https://research.fb.com/programs/openeds-challenge
+[12]:   https://github.com/rpng/open_vins
+[13]:   https://www.gnu.org/licenses/gpl-3.0.html
+[14]:   https://github.com/mp3guy/ElasticFusion
+[15]:   https://github.com/mp3guy/ElasticFusion/blob/master/LICENSE.txt
+[16]:   https://github.com/AayushKrChaudhary/RITnet
+[17]:   https://github.com/AayushKrChaudhary/RITnet/blob/master/License.md
+[18]:   https://github.com/videolabs/libspatialaudio
+[19]:   https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+[20]:   https://github.com/MartinPersson/HOTlab
+[21]:   https://www.gnu.org/licenses/lgpl-3.0.html
+[22]:   https://gitlab.freedesktop.org/monado/monado
+[23]:   https://choosealicense.com/licenses/bsl-1.0
+[24]:   https://gitter.im/ILLIXR/community
+[25]:   https://github.com/ILLIXR/ILLIXR/releases
+[26]:   https://www.khronos.org/openxr
+[27]:   https://github.com/ILLIXR/gtsam
+[28]:   https://github.com/borglab/gtsam/blob/develop/LICENSE.BSD
+[29]:   https://github.com/ILLIXR/Kimera-VIO
+[30]:   https://github.com/MIT-SPARK/Kimera-VIO/blob/master/LICENSE.BSD
+[31]:   https://github.com/cameron314/concurrentqueue
+[32]:   https://github.com/cameron314/concurrentqueue/blob/master/LICENSE.md
+[33]:   https://illixr.github.io/ILLIXR/getting_started/
+[34]:   https://illixr.github.io/ILLIXR/LICENSE/
+[35]:   https://illixr.github.io/ILLIXR/illixr_plugins/
+[36]:   https://illixr.github.io/ILLIXR/writing_your_plugin/
+[37]:   http://illixr.org
+[38]:   https://github.com/ILLIXR/ILLIXR
+[39]:   https://github.com/ILLIXR/ILLIXR/releases/tag/v1-latest
+[40]:   https://github.com/ILLIXR/KinectFusionApp/tree/illixr-integration
+[41]:   https://github.com/ILLIXR/ILLIXR/tree/master/realsense
+[42]:   https://www.nvidia.com/en-us/gtc/catalog/?search.primarytopic=option_1564595704881&search.sessiontype=option_1614028602338&search.primaryindustrysegment=option_1563402697134&search=An%20Open-Source%20Testbed#/
+[43]:   https://youtu.be/ZY98lWksnpM
+[44]:   https://ws.engr.illinois.edu/sitemanager/getfile.asp?id=2971
+[45]:   https://youtu.be/GVcCW8WgEDY
+[46]:   https://github.com/chrdiller/KinectFusionApp/blob/master/LICENSE.txt
+[47]:   https://discord.gg/upkvy7x3W4
+[48]:   mailto:lists@lists.cs.illinois.edu?subject=sub%20illixr-community
+[49]:   mailto:illixr@cs.illinois.edu


### PR DESCRIPTION
Closes #4.

Also, testing markdown stub format for external links. May need to revert to inline links.